### PR TITLE
chore: Fix missed `src/` vs `lib/` documentation

### DIFF
--- a/Errors.js
+++ b/Errors.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-module.exports = require('./lib/Errors');
+module.exports = require('./src/Errors');


### PR DESCRIPTION
Fixes #5591 more